### PR TITLE
Agrego v1 de Dockerfile para apps de BE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+
+FROM maven:3.9.9-eclipse-temurin-21 AS builder
+
+ARG APP_NAME=myapp
+
+WORKDIR /app/$APP_NAME
+
+COPY . .
+
+RUN mvn clean package -DskipTests
+
+


### PR DESCRIPTION
Dockerfile que recibe por parámetro el nombre de la app y crea el .jar correspondiente. La idea fue hacerlo reutilizable para poderlo utilizar desde los repos de todas las apps de BE.